### PR TITLE
fix: link to org instead of user in breadcrumb

### DIFF
--- a/templates/repo.html
+++ b/templates/repo.html
@@ -7,7 +7,7 @@
   <div class="breadcrumb">
     <a href="/" class="bc-link">ngmi</a>
     <span class="bc-sep">/</span>
-    <a href="/user/{{.Repo.Owner}}" class="bc-link">{{.Repo.Owner}}</a>
+    <a href="{{if and .OwnerUser .OwnerUser.IsOrg}}/org/{{else}}/user/{{end}}{{.Repo.Owner}}" class="bc-link">{{.Repo.Owner}}</a>
     <span class="bc-sep">/</span>
     <span class="bc-current">{{.Repo.Name}}</span>
   </div>


### PR DESCRIPTION
(this site is so sick btw)

## issue

on a page like https://ngmi.review/repo/PostHog/posthog , clicking the `PostHog` breadcrumb goes to `/user/PostHog`, when i think it should go to `/org/PostHog`.  

## solution

claude "fixed" it here by changing the hard-coded `/user/` link to check `.OwnerUser.IsOrg` and use `/org/` in those cases

**however** - i see a redirect to `/org/` from `/user/` exists if `ghUser.type == "Organization"`... so i'm not sure if that isn't working, or if `PostHog` is actually both a user _and_ an organization, or something like that?

also haven't tested this locally yet but will do shortly, i am entirely unfamiliar with go haha